### PR TITLE
Upgrade to BouncyCastle 1.46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
 			<dependency>
 				<groupId>org.bouncycastle</groupId>
 				<artifactId>bcprov-jdk16</artifactId>
-				<version>1.45</version>
+				<version>1.46</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>

--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/CRLChecker.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/CRLChecker.java
@@ -146,18 +146,9 @@ public class CRLChecker implements CertificateChecker {
             // validate CRL
             verifyCRL(caCert, crl);
 
-            /* One would have thought that a CRL is immutable and thus
-             * thread safe, however inside the ASN1 parse tree we find
-             * LazyDERSequence. LazyDERSequence is parsed lazily and
-             * does so in a non-thread safe manner. One may very well
-             * classify this as a bouncy castle bug, but as a
-             * workaround synchronizing on the CRL solves the problem.
-             */
-            synchronized (crl) {
-                if (crl.isRevoked(cert)) {
-                    throw new CertPathValidatorException(
-                        "Certificate " + cert.getSubjectDN() + " has been revoked");
-                }
+            if (crl.isRevoked(cert)) {
+                throw new CertPathValidatorException(
+                    "Certificate " + cert.getSubjectDN() + " has been revoked");
             }
         }
     }


### PR DESCRIPTION
Motivation:

LazyDERSequence in BouncyCastle 1.45 is not thread safe and we have
previously added a workaround for this race inside JGlobus. This
workaround leads to lock contention issues.

Modifications:

Upgrade to BouncyCastle 1.46 as it makes LazyDERSequence thread safe.

Result:

A future patch can remove the workaround for the race.
